### PR TITLE
Narrow return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,5 +3,5 @@ declare module "gender-detection-from-name" {
   export function getGender(
     name: string,
     lang?: Language,
-  ): string;
+  ): "male" | "female" | "unknown";
 }


### PR DESCRIPTION
I would have expected the typescript api to look more like this, which is in sync with https://github.com/DavideViolante/gender-detection-from-name/blob/master/index.js#L12

It probably shouldn't break for most users, unless you're matching wrong, it would show you the bug then. Otherwise it's easy to cast it to string again, when integrating with it.